### PR TITLE
Fix deprecation warnings

### DIFF
--- a/astconfman/app.py
+++ b/astconfman/app.py
@@ -6,12 +6,12 @@ from gevent.queue import Queue
 from urllib import urlencode
 from flask import Flask, send_from_directory, request, Response, session
 from flask import g, redirect, url_for
-from flask.ext.admin import Admin, AdminIndexView
-from flask.ext.babelex import Babel, gettext, lazy_gettext
-from flask.ext.migrate import Migrate
-from flask.ext.security import Security, SQLAlchemyUserDatastore, \
+from flask_admin import Admin, AdminIndexView
+from flask_babelex import Babel, gettext, lazy_gettext
+from flask_migrate import Migrate
+from flask_security import Security, SQLAlchemyUserDatastore, \
     UserMixin, RoleMixin, login_required
-from flask.ext.sqlalchemy import SQLAlchemy, models_committed
+from flask_sqlalchemy import SQLAlchemy, models_committed
 
 
 app = Flask('AstConfMan', instance_relative_config=True)

--- a/astconfman/asterisk.py
+++ b/astconfman/asterisk.py
@@ -2,7 +2,7 @@ import commands
 import os
 import shutil
 import tempfile
-from flask.ext.babelex import gettext
+from flask_babelex import gettext
 from transliterate import translit
 from app import app
 

--- a/astconfman/config.py
+++ b/astconfman/config.py
@@ -1,6 +1,6 @@
 # *-* encoding: utf-8 *-*
 import os
-from flask.ext.babelex import lazy_gettext as _
+from flask_babelex import lazy_gettext as _
 
 # Default Language. Currenly only 'ru' and 'en' are supported.
 LANGUAGE = 'en'

--- a/astconfman/forms.py
+++ b/astconfman/forms.py
@@ -1,10 +1,10 @@
 # *-* encoding:utf-8 *-*
 
-from flask.ext.wtf import Form
-from flask.ext.admin.form import BaseForm as BaseAdminForm
-from flask.ext.wtf.file import FileField, file_required, file_allowed
+from flask_wtf import Form
+from flask_admin.form import BaseForm as BaseAdminForm
+from flask_wtf.file import FileField, file_required, file_allowed
 from wtforms.validators import ValidationError
-from flask.ext.babelex import lazy_gettext as _
+from flask_babelex import lazy_gettext as _
 
 
 class ContactImportForm(Form):

--- a/astconfman/manage.py
+++ b/astconfman/manage.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
 from flask import Flask
-from flask.ext.babelex import gettext
-from flask.ext.migrate import MigrateCommand
-from flask.ext.security import utils
-from flask.ext.script import Manager
+from flask_babelex import gettext
+from flask_migrate import MigrateCommand
+from flask_security import utils
+from flask_script import Manager
 from app import app, db, migrate, user_datastore
 from models import Contact, Conference, Participant
 from models import ParticipantProfile, ConferenceProfile

--- a/astconfman/models.py
+++ b/astconfman/models.py
@@ -1,9 +1,9 @@
 from os.path import dirname, join
 from datetime import datetime
-from flask.ext.babelex import gettext, lazy_gettext
+from flask_babelex import gettext, lazy_gettext
 from datetime import datetime
 from sqlalchemy.ext.hybrid import hybrid_property
-from flask.ext.sqlalchemy import before_models_committed
+from flask_sqlalchemy import before_models_committed
 import asterisk
 from crontab import CronTab
 from app import app, db, sse_notify

--- a/astconfman/utils/validators.py
+++ b/astconfman/utils/validators.py
@@ -1,4 +1,4 @@
-from flask.ext.babelex import gettext
+from flask_babelex import gettext
 from wtforms.validators import ValidationError
 from crontab import CronTab, CronItem
 from models import Participant

--- a/astconfman/views.py
+++ b/astconfman/views.py
@@ -4,16 +4,16 @@ from os.path import dirname, join
 from crontab import CronTab
 from flask import request, render_template, Response, redirect, url_for
 from flask import Blueprint, flash, abort, jsonify
-from flask.ext.admin import  Admin, AdminIndexView, BaseView, expose
-from flask.ext.admin.contrib.sqla.ajax import QueryAjaxModelLoader
+from flask_admin import  Admin, AdminIndexView, BaseView, expose
+from flask_admin.contrib.sqla.ajax import QueryAjaxModelLoader
 from flask_admin import helpers as admin_helpers
-from flask.ext.admin.actions import action
-from flask.ext.admin.contrib.sqla import ModelView, filters
-from flask.ext.admin.contrib.fileadmin import FileAdmin
-from flask.ext.admin.form import rules
-from flask.ext.babelex import lazy_gettext as _, gettext
-from flask.ext.security import current_user
-from flask.ext.security.utils import encrypt_password
+from flask_admin.actions import action
+from flask_admin.contrib.sqla import ModelView, filters
+from flask_admin.contrib.fileadmin import FileAdmin
+from flask_admin.form import rules
+from flask_babelex import lazy_gettext as _, gettext
+from flask_security import current_user
+from flask_security.utils import encrypt_password
 from jinja2 import Markup
 from wtforms.fields import PasswordField
 from wtforms.validators import Required, ValidationError


### PR DESCRIPTION
Suppress warnings like this:
```
./manage.py:4: ExtDeprecationWarning: Importing flask.ext.babelex is deprecated, use flask_babelex instead.
  from flask.ext.babelex import gettext
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/litnimax/astconfman/46)
<!-- Reviewable:end -->
