### PR TITLE
High load HOTFIX

### DIFF
--- a/astconfman/views.py
+++ b/astconfman/views.py
@@ -979,7 +979,7 @@ talkers = []
 from asterisk2.ami import AMIClient
 from asterisk2.ami import AutoReconnect
 client = AMIClient(address='127.0.0.1',port=5038)
-client.login(username='admin',secret='7890ec8ff2955ec70a1b390b62f023da')
+client.login(username='conf',secret='7890ec8ff2955ec70a1b390b62f023da')
 from asterisk2.ami import EventListener
 AutoReconnect(client)
 

--- a/asterisk_etc/manager.conf
+++ b/asterisk_etc/manager.conf
@@ -8,7 +8,10 @@ enabled = yes
 port = 5038
 bindaddr = 127.0.0.1
 
-[admin]
+[conf]
 secret = 7890ec8ff2955ec70a1b390b62f023da
 read = system,call,log,verbose,command,agent,user,config,command,dtmf,reporting,cdr,dialplan,originate,message
 writetimeout = 5000
+;On high load systems amount of messages may overhelm python parser
+;to mitigate it use event filters
+eventfilter=ConfbridgeTalking


### PR DESCRIPTION
On high load systems amount of messages may overwhelm python parser, to mitigate it use event filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/litnimax/astconfman/61)
<!-- Reviewable:end -->
